### PR TITLE
Editing and displaylimits

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ const configuration_workflow = () =>
               {
                 name: "min_week_view_time",
                 type: "String",
-                label: "Min time in week views",
+                label: "Min time in week view",
                 sublabel:
                   "Min time to display in timeGridWeek, e.g. 08:00",
                 required: false,
@@ -255,7 +255,7 @@ const configuration_workflow = () =>
               {
                 name: "max_week_view_time",
                 type: "String",
-                label: "Max time in week views",
+                label: "Max time in week view",
                 sublabel:
                   "Max time to display in timeGridWeek, e.g. 20:00",
                 required: false,

--- a/index.js
+++ b/index.js
@@ -533,6 +533,15 @@ const update_calendar_event = async (
   if (role > table.min_role_write) {
     return { json: { error: req.__("Not authorized") } };
   }
+  const fields = await table.getFields();
+  if (
+    switch_to_duration &&
+    duration_field &&
+    fields &&
+    !fields.find((field) => field.name === duration_field)
+  ) {
+    return { json: { error: req.__("The duration column does not exist.") } };
+  }
   const row = await table.getRow({ id: rowId });
   let updateVals = {};
   let allDayChanged = false;
@@ -561,9 +570,9 @@ const update_calendar_event = async (
       const oldDuration = row[duration_field];
       if (newDuration !== oldDuration) updateVals[duration_field] = newDuration;
     }
-  } else if (isValidDate(endAsDate)) {
+  } else if (end_field && isValidDate(endAsDate)) {
     updateVals[end_field] = endAsDate;
-  } else if (allDayChanged && !isEmptyDelta(delta)) {
+  } else if (end_field && allDayChanged && !isEmptyDelta(delta)) {
     updateVals[end_field] = applyDelta(row[end_field], delta);
   }
   if (Object.keys(updateVals).length !== 0)


### PR DESCRIPTION
- activated event editing on the fullcalendar
  and added 'update_calendar_event' to update the database
- resizing in monthViews is only possible for allDayEvents
  and an end_field or duration must be configured
- added confuration parameters for
    min/max times (in timeGridWeek)
    filter out weekends (in timeGridWeek and dayGridWeek)
- added a toggle button to switch the display filters on/off
  by a user in the view