### PR TITLE
Avoid overriding configured custom views 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ You can also specify an edit view to create new events and a show/edit view to d
 ## Calendar views
 When setting up a calendar, you will have the option to specify different view options such as month, week, day, list, etc. You can use any of the default options listed in the "views" section of the [fullcalendar documentation](https://fullcalendar.io/docs).
 
-Advanced users can specify their own [views object](https://fullcalendar.io/docs/custom-view-with-settings). You can use your custom views in the other fields when setting up your calendar.
+Advanced users can specify their own [views object](https://fullcalendar.io/docs/custom-view-with-settings). You can use your custom views in the other fields when setting up your calendar. This will be appended to the inside of object under `views`
 
 Example of a custom views object:
 ```
-views: {
   timeGridFourDay: {
     type: 'timeGrid',
     duration: { days: 4 },
     buttonText: '4 day',
   },
-}
 ```

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Advanced users can specify their own [views object](https://fullcalendar.io/docs
 
 Example of a custom views object:
 ```
-  timeGridFourDay: {
+  myView: {
     type: 'timeGrid',
-    duration: { days: 4 },
-    buttonText: '4 day',
-  },
+    duration: { weeks: 1 },
+    buttonText: 'My View',
+    slotDuration: '00:15:00',
+  }
 ```

--- a/index.js
+++ b/index.js
@@ -864,7 +864,7 @@ const run = async (
     views: {
       dayGridWeek: dayGridWeekOpts,
       timeGridWeek: timeGridWeekOpts,
-      ${custom_calendar_views ? custom_calendar_views + "," : ""},
+      ${custom_calendar_views ? custom_calendar_views + "," : ""}
     },
     
   });

--- a/index.js
+++ b/index.js
@@ -866,7 +866,6 @@ const run = async (
       timeGridWeek: timeGridWeekOpts,
       ${custom_calendar_views ? custom_calendar_views + "," : ""}
     },
-    
   });
   calendar.render();`)
     ),

--- a/index.js
+++ b/index.js
@@ -657,8 +657,7 @@ const run = async (
       right: '${calendar_view_options}',
     },
     navLinks: true,
-    initialView: '${initialView}',
-    ${custom_calendar_views ? custom_calendar_views + "," : ""}
+    initialView: '${initialView}'
     nowIndicator: ${nowIndicator},
     weekNumbers: ${weekNumbers},
     eventColor: '${default_event_color}',
@@ -865,7 +864,9 @@ const run = async (
     views: {
       dayGridWeek: dayGridWeekOpts,
       timeGridWeek: timeGridWeekOpts,
+      ${custom_calendar_views ? custom_calendar_views + "," : ""},
     },
+    
   });
   calendar.render();`)
     ),

--- a/index.js
+++ b/index.js
@@ -657,7 +657,7 @@ const run = async (
       right: '${calendar_view_options}',
     },
     navLinks: true,
-    initialView: '${initialView}'
+    initialView: '${initialView}',
     nowIndicator: ${nowIndicator},
     weekNumbers: ${weekNumbers},
     eventColor: '${default_event_color}',


### PR DESCRIPTION
The value of the "Advanced: Custom calendar views" was ignored, this approach allows to not overwrite the `views:` value sent to fullCalendar